### PR TITLE
Fix ambient matching issue, provide some spring cleaning

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --profile 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+Documentation:
+  Exclude:
+    - lib/lita/handlers/onewheel_cve.rb
+
+FileName:
+  Exclude:
+    - lib/lita-onewheel-cve.rb
+
+LineLength:
+  Max: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.4
-  - 2.3.0
-script: bundle exec rake
-before_install:
-  - gem update --system
+  - 2.2
+  - 2.3
 services:
   - redis-server
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.2
-  - 2.3
+  - 2.3.0
 services:
   - redis-server
 cache: bundler

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+Pull requests are awesome!  Pull requests with tests are even more awesome!
+
+## Quick steps
+
+1. Fork the repo.
+2. Run the tests: `bundle && rake`
+3. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, it needs a test!
+4. Make the test pass.
+5. Push to your fork and submit a pull request.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2016 Andrew Kreps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,23 @@ lita-onewheel-cve
 ----
 |buildstatus|
 |coveragestatus|
+|license|
+|rubygems|
+|codeclimate|
+|gemnasium|
 
 .. |buildstatus| image:: https://travis-ci.org/onewheelskyward/lita-onewheel-cve.svg?branch=master
   :target: https://travis-ci.org/onewheelskyward/lita-onewheel-cve
 .. |coveragestatus| image:: https://coveralls.io/repos/github/onewheelskyward/lita-onewheel-cve/badge.svg?branch=master
   :target: https://coveralls.io/github/onewheelskyward/lita-onewheel-cve?branch=master
+.. |license| image:: https://img.shields.io/badge/license-MIT-brightgreen.svg
+  :target: https://tldrlegal.com/license/mit-license
+.. |rubygems| image:: http://img.shields.io/gem/v/lita-onewheel-cve.svg
+  :target: https://rubygems.org/gems/lita-onewheel-cve
+.. |codeclimate| image:: https://img.shields.io/codeclimate/github/onewheelskyward/lita-onewheel-cve.svg
+  :target: https://codeclimate.com/github/onewheelskyward/lita-onewheel-cve
+.. |gemnasium| image:: https://img.shields.io/gemnasium/onewheelskyward/lita-onewheel-cve.svg
+  :target: https://gemnasium.com/onewheelskyward/lita-onewheel-cve
 
 Puts out links to CVEs when they're posted in chat.
 

--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,18 @@ lita-onewheel-cve
 |buildstatus|
 |coveragestatus|
 
-.. |buildstatus| image:: https://travis-ci.org/onewheelskyward/lita-onewheel-cve.svg?branch=master 
+.. |buildstatus| image:: https://travis-ci.org/onewheelskyward/lita-onewheel-cve.svg?branch=master
   :target: https://travis-ci.org/onewheelskyward/lita-onewheel-cve
 .. |coveragestatus| image:: https://coveralls.io/repos/github/onewheelskyward/lita-onewheel-cve/badge.svg?branch=master
   :target: https://coveralls.io/github/onewheelskyward/lita-onewheel-cve?branch=master
 
 Puts out links to CVEs when they're posted in chat.
+
+Configuration
+----
+Optionally, override the default CVE search URL in your Lita configuration:
+
+``config.handlers.onewheel_cve.search_url = 'http://example.com/cve?id='``
 
 Installation
 ----
@@ -21,4 +27,3 @@ Usage
 When someone mentions 'CVE-1234-1234' it'll post a link to ``http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=1234-1234``.
 
 That's all, folks!
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new(:rubocop)
 
-task default: :spec
+task default: [:spec, :rubocop]

--- a/lib/lita-onewheel-cve.rb
+++ b/lib/lita-onewheel-cve.rb
@@ -8,5 +8,5 @@ require 'lita/handlers/onewheel_cve'
 
 Lita::Handlers::OnewheelCve.template_root File.expand_path(
   File.join('..', '..', 'templates'),
- __FILE__
+  __FILE__
 )

--- a/lib/lita/handlers/onewheel_cve.rb
+++ b/lib/lita/handlers/onewheel_cve.rb
@@ -1,11 +1,18 @@
 module Lita
   module Handlers
     class OnewheelCve < Handler
-      route /cve-(\d{4}-\d{4})/i, :handle_cve, help: {'text including cve-1234-1234' => 'Will return a link to cve.mitre.org.'}
+      route(
+        /cve-(\d{4}-\d{4})/i,
+        :handle_cve,
+        help: {
+          'text including cve-1234-1234' => 'Will return a link to cve.mitre.org.'
+        }
+      )
 
       def handle_cve(response)
         response.reply 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=' + response.matches[0][0]
       end
+
       Lita.register_handler(self)
     end
   end

--- a/lib/lita/handlers/onewheel_cve.rb
+++ b/lib/lita/handlers/onewheel_cve.rb
@@ -1,6 +1,8 @@
 module Lita
   module Handlers
     class OnewheelCve < Handler
+      config :search_url, default: 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name='
+
       route(
         /(\s|^)cve-(?<id>\d{4}-\d{4})/i,
         :handle_cve,
@@ -11,7 +13,7 @@ module Lita
 
       def handle_cve(response)
         id = response.match_data['id']
-        url = 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=' + id
+        url = config.search_url + id
         response.reply url
       end
 

--- a/lib/lita/handlers/onewheel_cve.rb
+++ b/lib/lita/handlers/onewheel_cve.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class OnewheelCve < Handler
       route(
-        /cve-(\d{4}-\d{4})/i,
+        /(\s|^)cve-(?<id>\d{4}-\d{4})/i,
         :handle_cve,
         help: {
           'text including cve-1234-1234' => 'Will return a link to cve.mitre.org.'
@@ -10,7 +10,9 @@ module Lita
       )
 
       def handle_cve(response)
-        response.reply 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=' + response.matches[0][0]
+        id = response.match_data['id']
+        url = 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=' + id
+        response.reply url
       end
 
       Lita.register_handler(self)

--- a/lita-onewheel-cve.gemspec
+++ b/lita-onewheel-cve.gemspec
@@ -4,12 +4,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Andrew Kreps']
   spec.email         = ['andrew.kreps@gmail.com']
   spec.description   = 'CVE decoder to pull the root link from a CVE posted in chat.'
-  spec.summary       = 'See desc.'
+  spec.summary       = spec.description
   spec.homepage      = 'https://github.com/onewheelskyward/lita-onewheel-cve'
   spec.license       = 'MIT'
   spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
@@ -17,10 +17,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'lita', '~> 4.7'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  # spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rack-test', '~> 0.6'
   spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov', '~> 0.11'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
 end

--- a/spec/lita/handlers/onewheel_cve_spec.rb
+++ b/spec/lita/handlers/onewheel_cve_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Lita::Handlers::OnewheelCve, lita_handler: true do
-  it { is_expected.to route('  cve-2015-1234  ') }
-  it { is_expected.to_not route('  cve-12-12  ') }
-  it { is_expected.to_not route('other text with cve within it  ') }
+  it { is_expected.to route('  cve-2015-1234  ').to(:handle_cve) }
+  it { is_expected.to_not route('  cve-12-12  ').to(:handle_cve) }
+  it { is_expected.to_not route('http://example.com/cve-2015-1234').to(:handle_cve) }
 
   it 'will return a cve link to the thing' do
     send_message 'oh man cve-2015-1234 is so awesome'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,20 @@ require 'lita-onewheel-cve'
 require 'lita/rspec'
 
 Lita.version_3_compatibility_mode = false
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.order = :random
+
+  Kernel.srand config.seed
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,4 @@ SimpleCov.start { add_filter '/spec/' }
 require 'lita-onewheel-cve'
 require 'lita/rspec'
 
-# A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
-# was generated with Lita 4, the compatibility mode should be left disabled.
 Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
Howdy!  So, I happened to run across this plugin while looking for an ambient matcher for CVE issues.  It works like a charm, thanks!

One issue - it matches CVE-ish things in other text (such as if someone drops a full CVE link).  I've fixed that in 2cccc86 by adding a space or start-of-line check to the regex & appropriate test.

This PR also includes several other commits to add or improve various items, let me know if you'd like anything added or removed!
